### PR TITLE
Fix skill name from 'Flashy☆Landing' to 'FlashyLanding'

### DIFF
--- a/web/src/assets/umamusume_final_skills_fixed.json
+++ b/web/src/assets/umamusume_final_skills_fixed.json
@@ -7338,7 +7338,7 @@
   },
   {
     "skill_id": "A_FlashystarLanding",
-    "name": "Flashy☆Landing",
+    "name": "FlashyLanding",
     "tier": "A",
     "skill_type": "Speed",
     "prerequisite_of": [],


### PR DESCRIPTION
It's @ line 7341. This is the web/scr/assets/umamusume_final_skills_fixed.json file.